### PR TITLE
Fixes EGI-FCTF/rOCCI-server#7

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,10 +48,12 @@ class ApplicationController < ActionController::API
 
   # Register supported MIME formats
   # @see 'config/initializers/mime_types.rb' for details
-  respond_to :json, :occi_json #, :xml, :occi_xml
-  respond_to :occi_header, :text, except: [:index]
+  respond_to :json, :occi_json, :occi_header, :text #, :xml, :occi_xml
   respond_to :uri_list, only: [:index]
   respond_to :html, only: [:index, :show]
+
+  # List of format targets for rendering into links only
+  INDEX_LINK_FORMATS = ['text/plain', 'text/occi', 'text/uri-list'].freeze
 
   # Provides access to a structure containing authentication data
   # intended for delegation to the backend.

--- a/app/controllers/compute_controller.rb
+++ b/app/controllers/compute_controller.rb
@@ -4,16 +4,18 @@
 class ComputeController < ApplicationController
   # GET /compute/
   def index
-    if request.format == 'text/uri-list'
+    if INDEX_LINK_FORMATS.include?(request.format)
       @computes = backend_instance.compute_list_ids
       @computes.map! { |c| "#{server_url}/compute/#{c}" }
+      options = { flag: :links_only }
     else
       @computes = Occi::Collection.new
       @computes.resources = backend_instance.compute_list
       update_mixins_in_coll(@computes)
+      options = {}
     end
 
-    respond_with(@computes)
+    respond_with(@computes, options)
   end
 
   # GET /compute/:id

--- a/app/controllers/network_controller.rb
+++ b/app/controllers/network_controller.rb
@@ -4,16 +4,18 @@
 class NetworkController < ApplicationController
   # GET /network/
   def index
-    if request.format == 'text/uri-list'
+    if INDEX_LINK_FORMATS.include?(request.format)
       @networks = backend_instance.network_list_ids
       @networks.map! { |c| "#{server_url}/network/#{c}" }
+      options = { flag: :links_only }
     else
       @networks = Occi::Collection.new
       @networks.resources = backend_instance.network_list
       update_mixins_in_coll(@networks)
+      options = {}
     end
 
-    respond_with(@networks)
+    respond_with(@networks, options)
   end
 
   # GET /network/:id

--- a/app/controllers/occi_model_controller.rb
+++ b/app/controllers/occi_model_controller.rb
@@ -4,21 +4,23 @@
 class OcciModelController < ApplicationController
   # GET /
   def index
-    if request.format == 'text/uri-list'
+    if INDEX_LINK_FORMATS.include?(request.format)
       @resources = []
 
       @resources.concat(backend_instance.compute_list_ids.map { |c| "#{server_url}/compute/#{c}" })
       @resources.concat(backend_instance.network_list_ids.map { |n| "#{server_url}/network/#{n}" })
       @resources.concat(backend_instance.storage_list_ids.map { |s| "#{server_url}/storage/#{s}" })
+      options = { flag: :links_only }
     else
       @resources = Occi::Collection.new
 
       @resources.resources.merge backend_instance.compute_list
       @resources.resources.merge backend_instance.network_list
       @resources.resources.merge backend_instance.storage_list
+      options = {}
     end
 
-    respond_with(@resources)
+    respond_with(@resources, options)
   end
 
   # GET /-/

--- a/app/controllers/os_tpl_controller.rb
+++ b/app/controllers/os_tpl_controller.rb
@@ -6,9 +6,18 @@ class OsTplController < ApplicationController
     # TODO: work with :term*
     mixins = Occi::Core::Mixins.new << Occi::Infrastructure::OsTpl.mixin
 
-    @computes = Occi::Collection.new
-    @computes.resources = backend_instance.compute_list(mixins)
-    respond_with(@computes)
+    if INDEX_LINK_FORMATS.include?(request.format)
+      @computes = backend_instance.compute_list_ids(mixins)
+      @computes.map! { |c| "#{server_url}/compute/#{c}" }
+      options = { flag: :links_only }
+    else
+      @computes = Occi::Collection.new
+      @computes.resources = backend_instance.compute_list(mixins)
+      update_mixins_in_coll(@computes)
+      options = {}
+    end
+
+    respond_with(@computes, options)
   end
 
   # POST /mixin/os_tpl/:term*/?action=:action

--- a/app/controllers/resource_tpl_controller.rb
+++ b/app/controllers/resource_tpl_controller.rb
@@ -6,9 +6,18 @@ class ResourceTplController < ApplicationController
     # TODO: work with :term*
     mixins = Occi::Core::Mixins.new << Occi::Infrastructure::ResourceTpl.mixin
 
-    @computes = Occi::Collection.new
-    @computes.resources = backend_instance.compute_list(mixins)
-    respond_with(@computes)
+    if INDEX_LINK_FORMATS.include?(request.format)
+      @computes = backend_instance.compute_list_ids(mixins)
+      @computes.map! { |c| "#{server_url}/compute/#{c}" }
+      options = { flag: :links_only }
+    else
+      @computes = Occi::Collection.new
+      @computes.resources = backend_instance.compute_list(mixins)
+      update_mixins_in_coll(@computes)
+      options = {}
+    end
+
+    respond_with(@computes, options)
   end
 
   # POST /mixin/resource_tpl/:term*/?action=:action

--- a/app/controllers/storage_controller.rb
+++ b/app/controllers/storage_controller.rb
@@ -4,16 +4,18 @@
 class StorageController < ApplicationController
   # GET /storage/
   def index
-    if request.format == 'text/uri-list'
+    if INDEX_LINK_FORMATS.include?(request.format)
       @storages = backend_instance.storage_list_ids
       @storages.map! { |c| "#{server_url}/storage/#{c}" }
+      options = { flag: :links_only }
     else
       @storages = Occi::Collection.new
       @storages.resources = backend_instance.storage_list
       update_mixins_in_coll(@storages)
+      options = {}
     end
 
-    respond_with(@storages)
+    respond_with(@storages, options)
   end
 
   # GET /storage/:id

--- a/config/initializers/occi_renderers.rb
+++ b/config/initializers/occi_renderers.rb
@@ -5,6 +5,9 @@ ActionController::Renderers.add :occi_header do |obj, options|
   if options[:flag] == :link_only
     headers['Location'] = obj
     'OK'
+  elsif options[:flag] == :links_only
+    headers['Location'] = obj.join(',')
+    ''
   elsif obj.respond_to?(:to_header)
     headers.merge!(obj.to_header)
     ''
@@ -23,6 +26,8 @@ ActionController::Renderers.add :text do |obj, options|
 
   if options[:flag] == :link_only
     "X-OCCI-Location: #{obj}"
+  elsif options[:flag] == :links_only
+    obj.collect { |link| "X-OCCI-Location: #{link}" }.join("\n")
   else
     obj.respond_to?(:to_text) ? obj.to_text : obj.to_s
   end

--- a/spec/controllers/compute_controller_spec.rb
+++ b/spec/controllers/compute_controller_spec.rb
@@ -19,6 +19,16 @@ describe ComputeController do
       expect(assigns(:computes)).to be_kind_of(Array)
     end
 
+    it 'returns an array for text/plain' do
+      get 'index', format: :text
+      expect(assigns(:computes)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/occi' do
+      get 'index', format: :occi_header
+      expect(assigns(:computes)).to be_kind_of(Array)
+    end
+
     it 'returns a collection with instances by default' do
       get 'index', format: :html
       expect(assigns(:computes)).not_to be_empty

--- a/spec/controllers/network_controller_spec.rb
+++ b/spec/controllers/network_controller_spec.rb
@@ -19,6 +19,16 @@ describe NetworkController do
       expect(assigns(:networks)).to be_kind_of(Array)
     end
 
+    it 'returns an array for text/plain' do
+      get 'index', format: :text
+      expect(assigns(:networks)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/occi' do
+      get 'index', format: :occi_header
+      expect(assigns(:networks)).to be_kind_of(Array)
+    end
+
     it 'returns a collection with instances by default' do
       get 'index', format: :html
       expect(assigns(:networks)).not_to be_empty

--- a/spec/controllers/occi_model_controller_spec.rb
+++ b/spec/controllers/occi_model_controller_spec.rb
@@ -14,12 +14,14 @@ describe OcciModelController do
       expect(response).to be_success
     end
 
-    it 'returns http not acceptable with PLAIN' do
-      expect { get 'index', format: :text }.to raise_error
+    it 'returns http success with PLAIN' do
+      get 'index', format: :text
+      expect(response).to be_success
     end
 
-    it 'returns http not acceptable with OCCI' do
-      expect { get 'index', format: :occi_header }.to raise_error
+    it 'returns http success with OCCI' do
+      get 'index', format: :occi_header
+      expect(response).to be_success
     end
 
   end

--- a/spec/controllers/os_tpl_controller_spec.rb
+++ b/spec/controllers/os_tpl_controller_spec.rb
@@ -7,9 +7,44 @@ describe OsTplController do
   describe "GET 'index'" do
 
     it 'returns http success' do
-      get 'index'
+      get 'index', format: :uri_list
       expect(response).to be_success
     end
+
+    it 'returns a collection by default' do
+      get 'index', format: :html
+      expect(assigns(:computes)).to be_kind_of(Occi::Collection)
+    end
+
+    it 'returns an array for text/uri-list' do
+      get 'index', format: :uri_list
+      expect(assigns(:computes)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/plain' do
+      get 'index', format: :text
+      expect(assigns(:computes)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/occi' do
+      get 'index', format: :occi_header
+      expect(assigns(:computes)).to be_kind_of(Array)
+    end
+
+    # it 'returns a collection with instances by default' do
+    #   get 'index', format: :html
+    #   expect(assigns(:computes)).not_to be_empty
+    # end
+
+    # it 'returns an array with links for text/uri-list' do
+    #   get 'index', format: :uri_list
+    #   expect(assigns(:computes)).not_to be_empty
+    # end
+
+    # it 'returns an array with /compute/ links for text/uri-list' do
+    #   get 'index', format: :uri_list
+    #   assigns(:computes).each { |cl| expect(cl).to include('/compute/') }
+    # end
 
   end
 

--- a/spec/controllers/resource_tpl_controller_spec.rb
+++ b/spec/controllers/resource_tpl_controller_spec.rb
@@ -7,9 +7,44 @@ describe ResourceTplController do
   describe "GET 'index'" do
 
     it 'returns http success' do
-      get 'index'
+      get 'index', format: :uri_list
       expect(response).to be_success
     end
+
+    it 'returns a collection by default' do
+      get 'index', format: :html
+      expect(assigns(:computes)).to be_kind_of(Occi::Collection)
+    end
+
+    it 'returns an array for text/uri-list' do
+      get 'index', format: :uri_list
+      expect(assigns(:computes)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/plain' do
+      get 'index', format: :text
+      expect(assigns(:computes)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/occi' do
+      get 'index', format: :occi_header
+      expect(assigns(:computes)).to be_kind_of(Array)
+    end
+
+    # it 'returns a collection with instances by default' do
+    #   get 'index', format: :html
+    #   expect(assigns(:computes)).not_to be_empty
+    # end
+
+    # it 'returns an array with links for text/uri-list' do
+    #   get 'index', format: :uri_list
+    #   expect(assigns(:computes)).not_to be_empty
+    # end
+
+    # it 'returns an array with /compute/ links for text/uri-list' do
+    #   get 'index', format: :uri_list
+    #   assigns(:computes).each { |cl| expect(cl).to include('/compute/') }
+    # end
 
   end
 

--- a/spec/controllers/storage_controller_spec.rb
+++ b/spec/controllers/storage_controller_spec.rb
@@ -19,6 +19,16 @@ describe StorageController do
       expect(assigns(:storages)).to be_kind_of(Array)
     end
 
+    it 'returns an array for text/plain' do
+      get 'index', format: :text
+      expect(assigns(:storages)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/occi' do
+      get 'index', format: :occi_header
+      expect(assigns(:storages)).to be_kind_of(Array)
+    end
+
     it 'returns a collection with instances by default' do
       get 'index', format: :html
       expect(assigns(:storages)).not_to be_empty


### PR DESCRIPTION
Adds multi-location rendering to `text/plain` and `text/occi`. All
resource locations will be rendered as 'X-OCCI-Location' or
'Location' depending on the MIME type. This fixes compatibility
issues.
