### PR TITLE
Fixed routing for *_tpl controllers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,16 +86,16 @@ ROCCIServer::Application.routes.draw do
   ####################################################
   ## Occi::Infrastructure::OsTpl
   ####################################################
-  get '/mixin/os_tpl/(:term/)', to: 'os_tpl#index', as: 'os_tpl'
+  get '/mixin/os_tpl(/:term)', to: 'os_tpl#index', as: 'os_tpl'
 
-  post '/mixin/os_tpl/(:term/)', to: 'os_tpl#trigger', constraints: { query_string: /^action=\S+$/ }
+  post '/mixin/os_tpl(/:term)', to: 'os_tpl#trigger', constraints: { query_string: /^action=\S+$/ }
 
   ####################################################
   ## Occi::Infrastructure::ResourceTpl
   ####################################################
-  get '/mixin/resource_tpl/(:term/)', to: 'resource_tpl#index', as: 'resource_tpl'
+  get '/mixin/resource_tpl(/:term)', to: 'resource_tpl#index', as: 'resource_tpl'
 
-  post '/mixin/resource_tpl/(:term/)', to: 'resource_tpl#trigger', constraints: { query_string: /^action=\S+$/ }
+  post '/mixin/resource_tpl(/:term)', to: 'resource_tpl#trigger', constraints: { query_string: /^action=\S+$/ }
 
   ####################################################
   ## Occi::Core::Mixin (user-defined mixins)


### PR DESCRIPTION
Dangling slashes were causing routing mistakes on *_tpl controllers.
Some requests were mistakenly routed as generic mixins, e.g.:

```
GET /mixin/os_tpl/debian6/  ->  MixinController
```

instead of

```
GET /mixin/os_tpl/debian6/  ->  OsTplController
```
