### PR TITLE
Fixes EGI-FCTF/rOCCI-server#23, default format

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,9 @@ class ApplicationController < ActionController::API
 
   include Mixins::ErrorHandling
 
+  # Set default media type/format if necessary
+  before_filter :set_default_format
+
   # Wrap actions in a request logger, only in non-production envs
   around_filter :global_request_logging if ROCCI_SERVER_CONFIG.common.log_requests_in_debug
 
@@ -226,5 +229,13 @@ class ApplicationController < ActionController::API
 
     matched = /^action=(?<act>\S+)$/.match(query_string)
     matched[:act]
+  end
+
+  # Checks request format and sets the default 'text/plain' if necessary.
+  def set_default_format
+    if request.format.symbol.nil? || request.format.to_s == '*/*'
+      logger.debug "[ApplicationController] Request format set to #{request.format.to_s.inspect}, forcing 'text/plain'"
+      request.format = :text
+    end
   end
 end

--- a/spec/controllers/compute_controller_spec.rb
+++ b/spec/controllers/compute_controller_spec.rb
@@ -9,7 +9,12 @@ describe ComputeController do
       expect(response).to be_success
     end
 
-    it 'returns a collection by default' do
+    it 'returns an array by default' do
+      get 'index', format: '*/*'
+      expect(assigns(:computes)).to be_kind_of(Array)
+    end
+
+    it 'returns a collection for text/html' do
       get 'index', format: :html
       expect(assigns(:computes)).to be_kind_of(Occi::Collection)
     end
@@ -29,7 +34,12 @@ describe ComputeController do
       expect(assigns(:computes)).to be_kind_of(Array)
     end
 
-    it 'returns a collection with instances by default' do
+    it 'returns an array with instances by default' do
+      get 'index', format: '*/*'
+      expect(assigns(:computes)).not_to be_empty
+    end
+
+    it 'returns a collection with instances for text/html' do
       get 'index', format: :html
       expect(assigns(:computes)).not_to be_empty
     end


### PR DESCRIPTION
Forcing default request format '_/_' to 'text/plain', as described
in the OCCI specification GFD.185 section 3.6.6.
