### PR TITLE
Requires needed when bundler is not used

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require 'rails-api'
+
 # Base class for all rOCCI-server's controllers. Implements
 # parsing and authentication callbacks, exposes user information,
 # declares supported media formats and handles raised errors.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+require 'logstasher'
+
 ROCCIServer::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require 'logstasher'
+
 ROCCIServer::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+require 'logstasher'
+
 ROCCIServer::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/initializers/10_configuration.rb
+++ b/config/initializers/10_configuration.rb
@@ -1,3 +1,6 @@
+require 'hashie'
+require 'ice_nine'
+
 # Initialize a Mash
 ROCCI_SERVER_CONFIG = Hashie::Mash.new
 

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,3 +1,5 @@
+require 'warden'
+
 # Insert Warden::Manager as Rack::Middleware
 Rails.configuration.middleware.insert_before Rack::Head, Warden::Manager do |manager|
   manager.default_strategies ROCCI_SERVER_CONFIG.common.authn_strategies.map { |strategy| strategy.to_sym }

--- a/config/version.rb
+++ b/config/version.rb
@@ -1,3 +1,5 @@
+require 'occi-core'
+
 module ROCCIServer
   VERSION = '1.0.5'
   ROCCI_VERSION = ::Occi::VERSION

--- a/lib/backends/opennebula/authn/cloud_auth_client.rb
+++ b/lib/backends/opennebula/authn/cloud_auth_client.rb
@@ -14,6 +14,7 @@
 # limitations under the License.                                             #
 #--------------------------------------------------------------------------- #
 
+require 'opennebula'
 require 'thread'
 
 module Backends::Opennebula::Authn


### PR DESCRIPTION
Packaging for distributions usually forbid or not recommend using bundler. This will explicitly add missing requires, which are normally covered by bundler.
