### PR TITLE
[EC2] Added endpoint config option to EC2 backend

### DIFF
--- a/etc/backends/ec2/development.yml
+++ b/etc/backends/ec2/development.yml
@@ -3,6 +3,7 @@ fixtures_dir: <%= File.join(Rails.application.config.rocci_server_etc_dir, 'back
 access_key_id: <%= ENV['ROCCI_SERVER_EC2_AWS_ACCESS_KEY_ID'] %>
 secret_access_key: <%= ENV['ROCCI_SERVER_EC2_AWS_SECRET_ACCESS_KEY'] %>
 aws_region: eu-west-1
+aws_endpoint: ''  # Do NOT change this value unless you know exactly what you are doing!
 aws_availability_zone: eu-west-1a
 image_filtering:
   policy: only_listed  # 'only_listed' or 'only_owned' or 'owned_and_listed' or 'all'

--- a/etc/backends/ec2/production.yml
+++ b/etc/backends/ec2/production.yml
@@ -3,6 +3,7 @@ fixtures_dir: <%= File.join(Rails.application.config.rocci_server_etc_dir, 'back
 access_key_id: <%= ENV['ROCCI_SERVER_EC2_AWS_ACCESS_KEY_ID'] %>
 secret_access_key: <%= ENV['ROCCI_SERVER_EC2_AWS_SECRET_ACCESS_KEY'] %>
 aws_region: <%= ENV['ROCCI_SERVER_EC2_AWS_REGION'] || 'eu-west-1' %>
+aws_endpoint: <%= ENV['ROCCI_SERVER_EC2_AWS_ENDPOINT'] || '' %>  # Do NOT change this value unless you know exactly what you are doing!
 aws_availability_zone: <%= ENV['ROCCI_SERVER_EC2_AWS_AVAILABILITY_ZONE'] || 'eu-west-1a' %>
 image_filtering:
   policy: <%= ENV['ROCCI_SERVER_EC2_IMAGE_FILTERING_POLICY'] || 'all' %>  # 'only_listed' or 'only_owned' or 'owned_and_listed' or 'all'

--- a/etc/backends/ec2/test.yml
+++ b/etc/backends/ec2/test.yml
@@ -3,6 +3,7 @@ fixtures_dir: <%= File.join(Rails.application.config.rocci_server_etc_dir, 'back
 access_key_id: <%= ENV['ROCCI_SERVER_EC2_AWS_ACCESS_KEY_ID'] %>
 secret_access_key: <%= ENV['ROCCI_SERVER_EC2_AWS_SECRET_ACCESS_KEY'] %>
 aws_region: eu-west-1
+aws_endpoint: ''  # Do NOT change this value unless you know exactly what you are doing!
 aws_availability_zone: eu-west-1a
 image_filtering:
   policy: only_listed  # 'only_listed' or 'only_owned' or 'owned_and_listed' or 'all'

--- a/examples/etc/apache2/sites-available/occi-ssl
+++ b/examples/etc/apache2/sites-available/occi-ssl
@@ -82,6 +82,7 @@
     SetEnv ROCCI_SERVER_EC2_AWS_ACCESS_KEY_ID          myec2accesskeyid
     SetEnv ROCCI_SERVER_EC2_AWS_SECRET_ACCESS_KEY      yourincrediblylonganddifficulttoguesspassword
     SetEnv ROCCI_SERVER_EC2_AWS_REGION                 eu-west-1
+    SetEnv ROCCI_SERVER_EC2_AWS_ENDPOINT               "" # Do NOT change this value unless you know exactly what you are doing!
     SetEnv ROCCI_SERVER_EC2_AWS_AVAILABILITY_ZONE      eu-west-1a
     SetEnv ROCCI_SERVER_EC2_IMAGE_FILTERING_POLICY     only_listed
     SetEnv ROCCI_SERVER_EC2_IMAGE_FILTERING_IMAGE_LIST "ami-896c96fe ami-f7f03d80 ami-4a5fb53d"

--- a/lib/backends/ec2_backend.rb
+++ b/lib/backends/ec2_backend.rb
@@ -11,6 +11,7 @@ module Backends
       @dalli_cache = dalli_cache
 
       ::Aws.config[:region] = @options.aws_region || "eu-west-1"
+      ::Aws.config[:endpoint] = @options.aws_endpoint unless @options.aws_endpoint.blank?
       @ec2_client = nil
 
       @options.backend_scheme ||= "http://occi.#{@server_properties.hostname || 'localhost'}"


### PR DESCRIPTION
This should only be used for 3rd-party EC2 implementations. AWS
EC2 will automatically select the right endpoint according to
the chosen zone.
