### PR TITLE
Added options for OpenSSL peer verification

### DIFF
--- a/config/initializers/force_ssl.rb
+++ b/config/initializers/force_ssl.rb
@@ -1,2 +1,5 @@
 # Force SSL according to settings in Rails.application.config.rocci_server_etc_dir/ENV.yml
 Rails.application.config.force_ssl = (ROCCI_SERVER_CONFIG.common.force_ssl.to_s == 'true')
+
+# Disable mandatory peer verification if SSL_CERT_* vars are not available
+OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE if ENV['SSL_CERT_FILE'].blank? && ENV['SSL_CERT_DIR'].blank?

--- a/examples/etc/apache2/sites-available/occi-ssl
+++ b/examples/etc/apache2/sites-available/occi-ssl
@@ -28,6 +28,10 @@
     # enable passing of SSL variables to passenger. For GridSite/VOMS, enable also exporting certificate data
     SSLOptions +StdEnvVars +ExportCertData
 
+    # configure OpenSSL inside rOCCI-server to validate peer certificates (for CMFs)
+    #SetEnv SSL_CERT_FILE /path/to/ca_bundle.crt
+    #SetEnv SSL_CERT_DIR  /etc/grid-security/certificates
+
     # set RackEnv
     RackEnv production
     LogLevel info


### PR DESCRIPTION
Peer verification in OpenSSL can be controlled via the following variables in Apache2 VHost files.
If both variables are unset, the mandatory peer verification will be turned off.

```
SetEnv SSL_CERT_FILE /path/to/ca_bundle.crt
SetEnv SSL_CERT_DIR  /etc/grid-security/certificates
```
