### PR TITLE
A batch of additional specs for the EC2 backend

### DIFF
--- a/spec/lib/backends/ec2_stubs/reservation_stub.yml
+++ b/spec/lib/backends/ec2_stubs/reservation_stub.yml
@@ -36,6 +36,12 @@
       :status: attached
       :attach_time: 2014-11-13 14:43:22.000000000 Z
       :delete_on_termination: true
+  - :device_name: "/dev/sdf"
+    :ebs:
+      :volume_id: vol-22574725
+      :status: attached
+      :attach_time: 2014-11-13 14:43:22.000000000 Z
+      :delete_on_termination: false
   :virtualization_type: hvm
   :client_token: YAoWX1415889798678
   :security_groups:

--- a/spec/lib/backends/ec2_stubs/reservations_stopped_stub.yml
+++ b/spec/lib/backends/ec2_stubs/reservations_stopped_stub.yml
@@ -1,0 +1,77 @@
+---
+:reservations:
+- :reservation_id: r-0e376eeb
+  :owner_id: '315503098552'
+  :groups: []
+  :instances:
+  - :instance_id: i-5a8b56be
+    :image_id: ami-6e7bd919
+    :state:
+      :code: 80
+      :name: stopped
+    :private_dns_name: ip-172-30-0-156.eu-west-1.compute.internal
+    :public_dns_name: ''
+    :state_transition_reason: User initiated (2015-01-14 14:07:24 GMT)
+    :key_name: sustr4
+    :ami_launch_index: 0
+    :product_codes: []
+    :instance_type: t2.micro
+    :launch_time: 2015-01-14 14:00:20.000000000 Z
+    :placement:
+      :availability_zone: eu-west-1a
+      :group_name: ''
+      :tenancy: default
+    :monitoring:
+      :state: disabled
+    :subnet_id: subnet-ec018e89
+    :vpc_id: vpc-8d00d6e8
+    :private_ip_address: 172.30.0.156
+    :state_reason:
+      :code: Client.UserInitiatedShutdown
+      :message: 'Client.UserInitiatedShutdown: User initiated shutdown'
+    :architecture: x86_64
+    :root_device_type: ebs
+    :root_device_name: "/dev/xvda"
+    :block_device_mappings:
+    - :device_name: "/dev/xvda"
+      :ebs:
+        :volume_id: vol-fa5e4ffd
+        :status: attached
+        :attach_time: 2015-01-13 12:04:36.000000000 Z
+        :delete_on_termination: true
+    - :device_name: "/dev/sdf"
+      :ebs:
+        :volume_id: vol-22574725
+        :status: attached
+        :attach_time: 2015-01-14 12:13:13.000000000 Z
+        :delete_on_termination: false
+    :virtualization_type: hvm
+    :client_token: NSRch1421150671757
+    :security_groups:
+    - :group_name: launch-wizard-2
+      :group_id: sg-c87ee7ad
+    :source_dest_check: true
+    :hypervisor: xen
+    :network_interfaces:
+    - :network_interface_id: eni-95c10cf1
+      :subnet_id: subnet-ec018e89
+      :vpc_id: vpc-8d00d6e8
+      :description: Primary network interface
+      :owner_id: '315503098552'
+      :status: in-use
+      :mac_address: 02:a4:40:32:85:f4
+      :private_ip_address: 172.30.0.156
+      :source_dest_check: true
+      :groups:
+      - :group_name: launch-wizard-2
+        :group_id: sg-c87ee7ad
+      :attachment:
+        :attachment_id: eni-attach-41edb40f
+        :device_index: 0
+        :status: attached
+        :attach_time: 2015-01-13 12:04:32.000000000 Z
+        :delete_on_termination: true
+      :private_ip_addresses:
+      - :private_ip_address: 172.30.0.156
+        :primary: true
+    :ebs_optimized: false

--- a/spec/lib/backends/ec2_stubs/reservations_storagelink_stub.yml
+++ b/spec/lib/backends/ec2_stubs/reservations_storagelink_stub.yml
@@ -1,0 +1,83 @@
+---
+:reservations:
+- :reservation_id: r-0e376eeb
+  :owner_id: '315503098552'
+  :groups: []
+  :instances:
+  - :instance_id: i-5a8b56be
+    :image_id: ami-6e7bd919
+    :state:
+      :code: 16
+      :name: running
+    :private_dns_name: ip-172-30-0-156.eu-west-1.compute.internal
+    :public_dns_name: ''
+    :state_transition_reason: ''
+    :key_name: sustr4
+    :ami_launch_index: 0
+    :product_codes: []
+    :instance_type: t2.micro
+    :launch_time: 2015-01-13 14:40:19.000000000 Z
+    :placement:
+      :availability_zone: eu-west-1a
+      :group_name: ''
+      :tenancy: default
+    :monitoring:
+      :state: disabled
+    :subnet_id: subnet-ec018e89
+    :vpc_id: vpc-8d00d6e8
+    :private_ip_address: 172.30.0.156
+    :public_ip_address: 54.154.118.155
+    :architecture: x86_64
+    :root_device_type: ebs
+    :root_device_name: "/dev/xvda"
+    :block_device_mappings:
+    - :device_name: "/dev/xvda"
+      :ebs:
+        :volume_id: vol-fa5e4ffd
+        :status: attached
+        :attach_time: 2015-01-13 12:04:36.000000000 Z
+        :delete_on_termination: true
+    - :device_name: "/dev/sdf"
+      :ebs:
+        :volume_id: vol-22574725
+        :status: attached
+        :attach_time: 2015-01-14 12:13:13.000000000 Z
+        :delete_on_termination: false
+    :virtualization_type: hvm
+    :client_token: NSRch1421150671757
+    :security_groups:
+    - :group_name: launch-wizard-2
+      :group_id: sg-c87ee7ad
+    :source_dest_check: true
+    :hypervisor: xen
+    :network_interfaces:
+    - :network_interface_id: eni-95c10cf1
+      :subnet_id: subnet-ec018e89
+      :vpc_id: vpc-8d00d6e8
+      :description: Primary network interface
+      :owner_id: '315503098552'
+      :status: in-use
+      :mac_address: 02:a4:40:32:85:f4
+      :private_ip_address: 172.30.0.156
+      :source_dest_check: true
+      :groups:
+      - :group_name: launch-wizard-2
+        :group_id: sg-c87ee7ad
+      :attachment:
+        :attachment_id: eni-attach-41edb40f
+        :device_index: 0
+        :status: attached
+        :attach_time: 2015-01-13 12:04:32.000000000 Z
+        :delete_on_termination: true
+      :association:
+        :public_ip: 54.154.118.155
+        :public_dns_name: ''
+        :ip_owner_id: amazon
+      :private_ip_addresses:
+      - :private_ip_address: 172.30.0.156
+        :primary: true
+        :association:
+          :public_ip: 54.154.118.155
+          :public_dns_name: ''
+          :ip_owner_id: amazon
+    :ebs_optimized: false

--- a/spec/lib/backends/ec2_stubs/starting_instances_stub.yml
+++ b/spec/lib/backends/ec2_stubs/starting_instances_stub.yml
@@ -1,0 +1,9 @@
+---
+:starting_instances:
+- :instance_id: i-22af91c7
+  :current_state:
+    :code: 0
+    :name: pending
+  :previous_state:
+    :code: 80
+    :name: stopped

--- a/spec/lib/backends/ec2_stubs/stopping_instances_stub.yml
+++ b/spec/lib/backends/ec2_stubs/stopping_instances_stub.yml
@@ -1,0 +1,9 @@
+---
+:stopping_instances:
+- :instance_id: i-22af91c7
+  :current_state:
+    :code: 64
+    :name: stopping
+  :previous_state:
+    :code: 16
+    :name: running

--- a/spec/lib/backends/ec2_stubs/volume_attaching_stub.yml
+++ b/spec/lib/backends/ec2_stubs/volume_attaching_stub.yml
@@ -1,0 +1,6 @@
+---
+:volume_id: vol-b42b08b3
+:instance_id: i-22af91c7
+:device: "/dev/xvdf"
+:state: attaching
+:attach_time: 2015-01-13 10:41:40.712000000 Z

--- a/spec/lib/backends/ec2_stubs/volume_detaching_stub.yml
+++ b/spec/lib/backends/ec2_stubs/volume_detaching_stub.yml
@@ -1,0 +1,6 @@
+---
+:volume_id: vol-b42b08b3
+:instance_id: i-22af91c7
+:device: "/dev/xvdf"
+:state: detaching
+:attach_time: 2015-01-13 10:41:40.000000000 Z

--- a/spec/lib/backends/ec2_stubs/volumes_deleted_stub.yml
+++ b/spec/lib/backends/ec2_stubs/volumes_deleted_stub.yml
@@ -1,0 +1,12 @@
+---
+:volumes:
+- :volume_id: vol-22574725
+  :size: 1
+  :snapshot_id: ''
+  :availability_zone: eu-west-1a
+  :state: deleted
+  :create_time: 2015-01-14 12:12:23.254000000 Z
+  :attachments:
+  :volume_type: gp2
+  :iops: 3
+  :encrypted: false

--- a/spec/lib/backends/ec2_stubs/volumes_storagelink_stub.yml
+++ b/spec/lib/backends/ec2_stubs/volumes_storagelink_stub.yml
@@ -1,0 +1,18 @@
+---
+:volumes:
+- :volume_id: vol-22574725
+  :size: 1
+  :snapshot_id: ''
+  :availability_zone: eu-west-1a
+  :state: in-use
+  :create_time: 2015-01-14 12:12:23.254000000 Z
+  :attachments:
+  - :volume_id: vol-22574725
+    :instance_id: i-5a8b56be
+    :device: "/dev/sdf"
+    :state: attached
+    :attach_time: 2015-01-14 12:13:13.000000000 Z
+    :delete_on_termination: false
+  :volume_type: gp2
+  :iops: 3
+  :encrypted: false


### PR DESCRIPTION
- Specs for attaching a private network
  - Unsupported operation, only test that code throws exception
- Storage attach/detach specs
- Specs for network detach and related methods
- Storage link get spec
- Specs for triggering actions on compute