### PR TITLE
Fixes EGI-FCTF/rOCCI-server#113

### DIFF
--- a/etc/backends/opennebula/development.yml
+++ b/etc/backends/opennebula/development.yml
@@ -4,3 +4,4 @@ templates_dir: <%= File.join(Rails.application.config.rocci_server_etc_dir, 'bac
 xmlrpc_endpoint: <%= ENV['ROCCI_SERVER_ONE_XMLRPC'] %>
 username: <%= ENV['ROCCI_SERVER_ONE_USER'] %>
 password: <%= ENV['ROCCI_SERVER_ONE_PASSWD'] %>
+storage_datastore_id: <%= ENV['ROCCI_SERVER_ONE_STORAGE_DATASTORE_ID'] || '1' %>

--- a/etc/backends/opennebula/production.yml
+++ b/etc/backends/opennebula/production.yml
@@ -4,3 +4,4 @@ templates_dir: <%= File.join(Rails.application.config.rocci_server_etc_dir, 'bac
 xmlrpc_endpoint: <%= ENV['ROCCI_SERVER_ONE_XMLRPC'] %>
 username: <%= ENV['ROCCI_SERVER_ONE_USER'] %>
 password: <%= ENV['ROCCI_SERVER_ONE_PASSWD'] %>
+storage_datastore_id: <%= ENV['ROCCI_SERVER_ONE_STORAGE_DATASTORE_ID'] || '1' %>

--- a/etc/backends/opennebula/test.yml
+++ b/etc/backends/opennebula/test.yml
@@ -4,3 +4,4 @@ templates_dir: <%= File.join(Rails.application.config.rocci_server_etc_dir, 'bac
 xmlrpc_endpoint: <%= ENV['ROCCI_SERVER_ONE_XMLRPC'] %>
 username: <%= ENV['ROCCI_SERVER_ONE_USER'] %>
 password: <%= ENV['ROCCI_SERVER_ONE_PASSWD'] %>
+storage_datastore_id: <%= ENV['ROCCI_SERVER_ONE_STORAGE_DATASTORE_ID'] || '1' %>

--- a/examples/etc/apache2/sites-available/occi-ssl
+++ b/examples/etc/apache2/sites-available/occi-ssl
@@ -96,6 +96,7 @@
     SetEnv ROCCI_SERVER_ONE_XMLRPC  http://localhost:2633/RPC2
     SetEnv ROCCI_SERVER_ONE_USER    rocci
     SetEnv ROCCI_SERVER_ONE_PASSWD  yourincrediblylonganddifficulttoguesspassword
+    #SetEnv ROCCI_SERVER_ONE_STORAGE_DATASTORE_ID 1
 
     ## EC2 backend
     SetEnv ROCCI_SERVER_EC2_AWS_ACCESS_KEY_ID          myec2accesskeyid

--- a/lib/backends/opennebula/storage.rb
+++ b/lib/backends/opennebula/storage.rb
@@ -1,7 +1,6 @@
 module Backends
   module Opennebula
     module Storage
-      DEFAULT_DATASTORE_ID = 1
 
       # Gets all storage instance IDs, no details, no duplicates. Returned
       # identifiers must correspond to those found in the occi.core.id
@@ -89,7 +88,8 @@ module Backends
       # @param storage [Occi::Infrastructure::Storage] storage instance containing necessary attributes
       # @return [String] final identifier of the new storage instance
       def storage_create(storage)
-        @logger.debug "[Backends] [OpennebulaBackend] Creating storage #{storage.inspect}"
+        @logger.debug "[Backends] [OpennebulaBackend] Creating storage #{storage.inspect} "\
+                      "in DS[#{@options.storage_datastore_id}]"
 
         # include some basic mixins
         # WARNING: adding mix-ins will re-set their attributes
@@ -105,7 +105,7 @@ module Backends
         image_alloc = ::OpenNebula::Image.build_xml
         backend_object = ::OpenNebula::Image.new(image_alloc, @client)
 
-        rc = backend_object.allocate(template, DEFAULT_DATASTORE_ID)
+        rc = backend_object.allocate(template, @options.storage_datastore_id.to_i)
         check_retval(rc, Backends::Errors::ResourceCreationError)
 
         rc = backend_object.info


### PR DESCRIPTION
ONe datastore for OCCI block storage is now configurable:
~~~
SetEnv  ROCCI_SERVER_ONE_STORAGE_DATASTORE_ID  1   # DS_ID(int)
~~~