### PR TITLE
Configure & control Rubocop, fix lint in backends

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,49 @@
+# Turning off Style cops for the time being
+Style:
+  Enabled: false
+
+# Turning off Metrics cops for the time being
+Metrics:
+  Enabled: false
+
+# Turning off Performance cops for the time being
+Performance:
+  Enabled: false
+
+# Rubocop does not fully understand rspec syntax
+Lint/UselessAssignment:
+  Exclude:
+    - 'spec/**/*'
+
+# Unused arguments occur naturally in backends. Cannot be considered as bugs
+Lint/UnusedMethodArgument:
+  Exclude:
+    - 'lib/backends/**/*'
+
+# Only appli cops to backends
+AllCops:
+  Include:
+    - 'lib/backends/**/*'
+  Exclude:
+    - '*'
+    - 'etc/**/*'
+    - '.bundle/**/*'
+    - 'spec/**/*'
+    - 'examples/**/*'
+    - '.git/**/*'
+    - 'vendor/**/*'
+    - 'bin/**/*'
+    - 'log/**/*'
+    - 'config/**/*'
+    - 'public/**/*'
+    - 'test/**/*'
+    - 'app/**/*'
+    - 'coverage/**/*'
+    - 'db/**/*'
+    - 'lib/authentication_strategies/**/*'
+    - 'lib/errors/**/*'
+    - 'lib/tasks/**/*'
+    - 'lib/request_parsers/**/*'
+    - 'lib/assets/**/*'
+    - 'lib/hooks/**/*'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,3 @@ DEPENDENCIES
   web-console (~> 2.0)
   whenever
   yard
-
-BUNDLED WITH
-   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,3 +298,6 @@ DEPENDENCIES
   web-console (~> 2.0)
   whenever
   yard
+
+BUNDLED WITH
+   1.10.5

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,16 +98,18 @@ ROCCIServer::Application.configure do
   config.logstasher.suppress_app_log = false
 
   # This line is optional, it allows you to set a custom value for the @source field of the log event
-  config.logstasher.source = if ENV['ROCCI_SERVER_HOSTNAME'].blank? || ENV['ROCCI_SERVER_PORT'].blank?
-    (`hostname -f` || 'unknown').chomp
-  else
-    "#{ENV['ROCCI_SERVER_HOSTNAME']}_#{ENV['ROCCI_SERVER_PORT']}"
-  end
+  config.logstasher.source =
+    if ENV['ROCCI_SERVER_HOSTNAME'].blank? || ENV['ROCCI_SERVER_PORT'].blank?
+      (`hostname -f` || 'unknown').chomp
+    else
+      "#{ENV['ROCCI_SERVER_HOSTNAME']}_#{ENV['ROCCI_SERVER_PORT']}"
+    end
 
   # Set path to configuration files
-  config.rocci_server_etc_dir = if ENV['ROCCI_SERVER_ETC_DIR'].blank?
-    Rails.root.join('etc')
-  else
-    Pathname.new(ENV['ROCCI_SERVER_ETC_DIR'])
-  end
+  config.rocci_server_etc_dir =
+    if ENV['ROCCI_SERVER_ETC_DIR'].blank?
+      Rails.root.join('etc')
+    else
+      Pathname.new(ENV['ROCCI_SERVER_ETC_DIR'])
+    end
 end

--- a/lib/backends/dummy/base.rb
+++ b/lib/backends/dummy/base.rb
@@ -32,7 +32,7 @@ module Backends
 
       def read_fixtures(base_path)
         @logger.debug "[Backends] [Dummy] Reading fixtures from #{base_path.to_s.inspect}"
-        (FIXTURES + FIXTURES_TPL).each { |name| send "read_#{name.to_s}_fixtures", base_path }
+        (FIXTURES + FIXTURES_TPL).each { |name| send "read_#{name}_fixtures", base_path }
       end
 
       FIXTURES.each do |fixture|
@@ -94,7 +94,7 @@ end
         fail Backends::Errors::ResourceRetrievalError, "Unable to read fixtures " \
              "for #{fixture_type.to_s.inspect}!" unless (FIXTURES + FIXTURES_TPL).include? fixture_type
 
-        File.join(path, "#{fixture_type.to_s}.json")
+        File.join(path, "#{fixture_type}.json")
       end
     end
   end

--- a/lib/backends/ec2/authn/ec2_credentials_helper.rb
+++ b/lib/backends/ec2/authn/ec2_credentials_helper.rb
@@ -28,8 +28,6 @@ module Backends::Ec2::Authn
       end
     end
 
-    private
-
     # Converts given basic credentials to credentials supported
     # by AWS. Username is used as access_key_id and password as
     # secret_access_key.

--- a/lib/backends/ec2/compute.rb
+++ b/lib/backends/ec2/compute.rb
@@ -447,8 +447,8 @@ module Backends
         filters << { name: 'image-id', values: @image_filtering_image_list } if IMAGE_FILTERING_POLICIES_LISTED.include?(@image_filtering_policy)
         owners = IMAGE_FILTERING_POLICIES_OWNED.include?(@image_filtering_policy) ? [ 'self' ] : nil
 
-        ec2_images_ary = nil
-        unless ec2_images_ary = Backends::Helpers::CachingHelper.load(@dalli_cache, DALLI_OS_TPL_KEY)
+        ec2_images_ary = Backends::Helpers::CachingHelper.load(@dalli_cache, DALLI_OS_TPL_KEY)
+        unless ec2_images_ary
           ec2_images_ary = []
 
           Backends::Ec2::Helpers::AwsConnectHelper.rescue_aws_service(@logger) do

--- a/lib/backends/ec2/helpers/compute_create_helper.rb
+++ b/lib/backends/ec2/helpers/compute_create_helper.rb
@@ -151,7 +151,7 @@ module Backends
                 waiter.interval = 5      # number of seconds to sleep between attempts
                 waiter.max_attempts = nil # maximum number of polling attempts
 
-                waiter.before_attempt do |attempt|
+                waiter.before_attempt do
                   throw(:failure, 'waited too long') if Time.now > timeout_deadline
                 end
               end

--- a/lib/backends/ec2/helpers/compute_parse_helper.rb
+++ b/lib/backends/ec2/helpers/compute_parse_helper.rb
@@ -7,7 +7,8 @@ module Backends
         def parse_backend_obj(backend_compute, reservation_id)
           compute = ::Occi::Infrastructure::Compute.new
 
-          if os_tpl_mixin = get_resource_tpl(itype_to_term(backend_compute[:instance_type]))
+          os_tpl_mixin = get_resource_tpl(itype_to_term(backend_compute[:instance_type]))
+          if os_tpl_mixin
             compute.mixins << os_tpl_mixin
             compute.attributes['occi.compute.cores'] = os_tpl_mixin.attributes.occi_.compute_.cores.default
             compute.attributes['occi.compute.memory'] = os_tpl_mixin.attributes.occi_.compute_.memory.default
@@ -127,7 +128,7 @@ module Backends
               result_network_links << parse_link_networkinterface(compute, intf)
             end
           else
-            intfs.each { |intf| result_network_links << parse_link_networkinterface(compute, intf) }
+            intfs.each { |intfc| result_network_links << parse_link_networkinterface(compute, intfc) }
           end
 
           result_network_links.compact
@@ -171,8 +172,6 @@ module Backends
 
           link
         end
-
-        private
 
         def parse_link_networkinterface_is_vpc_pub?(intf_address)
           return if intf_address.blank?

--- a/lib/backends/ec2/helpers/network_dummy_helper.rb
+++ b/lib/backends/ec2/helpers/network_dummy_helper.rb
@@ -17,7 +17,7 @@ module Backends
           network.mixins << 'http://schemas.ogf.org/occi/infrastructure/network#ipnetwork'
 
           network.id = type.to_s
-          network.title = "Generated network representing EC2's #{type.to_s} address range"
+          network.title = "Generated network representing EC2's #{type} address range"
           network.state = 'active'
           network.label = type.to_s
 

--- a/lib/backends/ec2/helpers/network_parse_helper.rb
+++ b/lib/backends/ec2/helpers/network_parse_helper.rb
@@ -8,11 +8,12 @@ module Backends
           network.mixins << 'http://schemas.ec2.aws.amazon.com/occi/infrastructure/network#aws_ec2_vpc'
 
           network.attributes['occi.core.id'] = backend_network[:vpc_id]
-          network.attributes['occi.core.title'] = if backend_network[:tags].select { |tag| tag[:key] == 'Name' }.any?
-            backend_network[:tags].select { |tag| tag[:key] == 'Name' }.first[:value]
-          else
-            "rOCCI-server VPC #{backend_network[:cidr_block]}"
-          end
+          network.attributes['occi.core.title'] =
+            if backend_network[:tags].select { |tag| tag[:key] == 'Name' }.any?
+              backend_network[:tags].select { |tag| tag[:key] == 'Name' }.first[:value]
+            else
+              "rOCCI-server VPC #{backend_network[:cidr_block]}"
+            end
           network.address = backend_network[:cidr_block] unless backend_network[:cidr_block].blank?
           network.attributes['occi.network.label'] = "AWS VPC #{backend_network[:vpc_id]}"
 

--- a/lib/backends/ec2/helpers/storage_parse_helper.rb
+++ b/lib/backends/ec2/helpers/storage_parse_helper.rb
@@ -8,11 +8,12 @@ module Backends
           storage.mixins << 'http://schemas.ec2.aws.amazon.com/occi/infrastructure/storage#aws_ec2_ebs_volume'
 
           storage.attributes['occi.core.id'] = backend_storage[:volume_id]
-          storage.attributes['occi.core.title'] = if backend_storage[:tags].select { |tag| tag[:key] == 'Name' }.any?
-            backend_storage[:tags].select { |tag| tag[:key] == 'Name' }.first[:value]
-          else
-            "rOCCI-server volume #{backend_storage[:size]}GB"
-          end
+          storage.attributes['occi.core.title'] =
+            if backend_storage[:tags].select { |tag| tag[:key] == 'Name' }.any?
+              backend_storage[:tags].select { |tag| tag[:key] == 'Name' }.first[:value]
+            else
+              "rOCCI-server volume #{backend_storage[:size]}GB"
+            end
           storage.attributes['occi.storage.size'] = backend_storage[:size]
 
           storage.attributes['com.amazon.aws.ec2.availability_zone'] = backend_storage[:availability_zone] if backend_storage[:availability_zone]

--- a/lib/backends/ec2/network.rb
+++ b/lib/backends/ec2/network.rb
@@ -262,7 +262,6 @@ module Backends
       def trigger_action(network_id, action_instance)
         fail Backends::Errors::ActionNotImplementedError,
              "Action #{action_instance.action.type_identifier.inspect} is not implemented!"
-        true
       end
 
       # Returns a collection of custom mixins introduced (and specific for)
@@ -272,8 +271,6 @@ module Backends
       def get_extensions
         read_extensions 'network', @options.model_extensions_dir
       end
-
-      private
 
       # Load methods called from list/get
       include Backends::Ec2::Helpers::NetworkParseHelper

--- a/lib/backends/ec2/storage.rb
+++ b/lib/backends/ec2/storage.rb
@@ -249,8 +249,6 @@ module Backends
         read_extensions 'storage', @options.model_extensions_dir
       end
 
-      private
-
       # Load methods called from list/get
       include Backends::Ec2::Helpers::StorageParseHelper
 

--- a/lib/backends/opennebula/helpers/compute_action_helper.rb
+++ b/lib/backends/opennebula/helpers/compute_action_helper.rb
@@ -25,7 +25,7 @@ module Backends
                  "Given action is not allowed in this state! [#{backend_object.lcm_state_str.inspect}]"
             end
           when 'FAILED'
-            rc = backend_object.delete(recreate = true)
+            rc = backend_object.delete(true) # recreate = true
           else
             fail ::Backends::Errors::ResourceActionError,
                  "Given action is not allowed in this state! [#{backend_object.state_str.inspect}]"

--- a/lib/backends/opennebula/helpers/compute_create_helper.rb
+++ b/lib/backends/opennebula/helpers/compute_create_helper.rb
@@ -149,14 +149,15 @@ module Backends
         def create_add_description(compute, template)
           return if compute.blank? || template.nil?
 
-          new_desc = if !compute.summary.blank?
-            compute.summary
-          elsif !template['TEMPLATE/DESCRIPTION'].blank?
-            "#{template['TEMPLATE/DESCRIPTION']}#{template['TEMPLATE/DESCRIPTION'].end_with?('.') ? '' : '.' }" \
-            " Instantiated with rOCCI-server on #{::DateTime.now.readable_inspect}."
-          else
-            "Instantiated with rOCCI-server on #{::DateTime.now.readable_inspect}."
-          end
+          new_desc =
+            if !compute.summary.blank?
+              compute.summary
+            elsif !template['TEMPLATE/DESCRIPTION'].blank?
+              "#{template['TEMPLATE/DESCRIPTION']}#{template['TEMPLATE/DESCRIPTION'].end_with?('.') ? '' : '.' }" \
+              " Instantiated with rOCCI-server on #{::DateTime.now.readable_inspect}."
+            else
+              "Instantiated with rOCCI-server on #{::DateTime.now.readable_inspect}."
+            end
 
           template.delete_element('TEMPLATE/DESCRIPTION')
           template.add_element('TEMPLATE', 'DESCRIPTION' => new_desc)

--- a/lib/backends/opennebula/helpers/compute_parse_helper.rb
+++ b/lib/backends/opennebula/helpers/compute_parse_helper.rb
@@ -97,11 +97,12 @@ module Backends
             context_attrs[CONTEXTUALIZATION_ATTR_KEY] = backend_compute['TEMPLATE/CONTEXT/SSH_PUBLIC_KEY'] || backend_compute['TEMPLATE/CONTEXT/SSH_KEY']
 
             # re-encode cloud-init configuration files as Base64
-            context_attrs[CONTEXTUALIZATION_ATTR_UD] = if backend_compute['TEMPLATE/CONTEXT/USER_DATA'] && backend_compute['TEMPLATE/CONTEXT/USER_DATA'].match(/^\s*#cloud-config\s*$/)
-              Base64.strict_encode64(backend_compute['TEMPLATE/CONTEXT/USER_DATA'])
-            else
-              backend_compute['TEMPLATE/CONTEXT/USER_DATA']
-            end
+            context_attrs[CONTEXTUALIZATION_ATTR_UD] =
+              if backend_compute['TEMPLATE/CONTEXT/USER_DATA'] && backend_compute['TEMPLATE/CONTEXT/USER_DATA'].match(/^\s*#cloud-config\s*$/)
+                Base64.strict_encode64(backend_compute['TEMPLATE/CONTEXT/USER_DATA'])
+              else
+                backend_compute['TEMPLATE/CONTEXT/USER_DATA']
+              end
           end
 
           context_attrs

--- a/lib/backends/opennebula/network.rb
+++ b/lib/backends/opennebula/network.rb
@@ -245,8 +245,6 @@ module Backends
         read_extensions 'network', @options.model_extensions_dir
       end
 
-      private
-
       # Load methods called from list/get
       include Backends::Opennebula::Helpers::NetworkParseHelper
     end

--- a/lib/backends/opennebula/storage.rb
+++ b/lib/backends/opennebula/storage.rb
@@ -259,8 +259,6 @@ module Backends
         read_extensions 'storage', @options.model_extensions_dir
       end
 
-      private
-
       # Load methods called from list/get
       include Backends::Opennebula::Helpers::StorageParseHelper
 


### PR DESCRIPTION
This is an attempt to cheaply satisfy minimum requirements for rOCCI-server release in INDIGO. The idea is to check only for problems considered serious (act like `rubocop --lint`), and only check backends because that is where INDIGO contributes for now. I also had to disable the `Lint/UnusedMethodArgument` cop because Rubocop does not understand the idea of generic functions.

Please see if you are willing to accept this, and let me know if you want something changed.

This PR includes:
- `.rubocop.yml` config file to limit the scope of checking to backends, and skip unapplicable cops
- 1st attempt to resolve Rubocop lint errors in backends