### PR TITLE
Support for resizing created compute instances

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -89,13 +89,14 @@ class ApplicationController < ActionController::Base
   # by the RequestParser.
   #
   # @param expected_entity_type [Object] parameter passed as 'entity_type' to Occi::Parser.parse
+  # @param expect_categories [Boolean] parameter passed as 'categories' to Occi::Parser.parse
   # @return [Occi::Collection] collection containig parsed OCCI request
-  def request_occi_collection(expected_entity_type = nil)
+  def request_occi_collection(expected_entity_type = nil, expect_categories = false)
     if Rails.env.test?
       # turn off caching for tests
-      @request_collection = parse_request(expected_entity_type)
+      @request_collection = parse_request(expected_entity_type, expect_categories)
     else
-      @request_collection ||= parse_request(expected_entity_type)
+      @request_collection ||= parse_request(expected_entity_type, expect_categories)
     end
   end
 
@@ -116,9 +117,10 @@ class ApplicationController < ActionController::Base
   # Provides access to a lazy parser object
   #
   # @param expected_entity_type [Object] parameter passed as 'entity_type' to Occi::Parser.parse
+  # @param expect_categories [Boolean] parameter passed as 'categories' to Occi::Parser.parse
   # @return [Occi::Collection] collection of parsed OCCI objects
-  def parse_request(expected_entity_type = nil)
-    request_collection = request.env['rocci_server.request.parser'].parse_occi_messages(expected_entity_type)
+  def parse_request(expected_entity_type = nil, expect_categories = false)
+    request_collection = request.env['rocci_server.request.parser'].parse_occi_messages(expected_entity_type, expect_categories)
     request_collection ||= Occi::Collection.new
 
     request_collection.model = OcciModel.get(backend_instance)

--- a/lib/backends/dummy/compute.rb
+++ b/lib/backends/dummy/compute.rb
@@ -215,8 +215,16 @@ module Backends
       # @param links [::Occi::Core::Links] a collection of links to be added
       # @return [true, false] result of the operation
       def partial_update(compute_id, attributes = nil, mixins = nil, links = nil)
-        # TODO: impl
-        fail Backends::Errors::MethodNotImplementedError, 'Partial updates are currently not supported!'
+        if attributes.blank? && mixins.blank? && links.blank?
+          fail ::Errors::ArgumentTypeMismatchError, 'Nothing to update!'
+        end
+
+        compute = get(compute_id)
+        compute.attributes = attributes unless attributes.blank?
+        compute.mixins = mixins unless mixins.blank?
+        compute.links = links unless links.blank?
+
+        update(compute)
       end
 
       # Updates an existing compute instance, instance to be updated is specified

--- a/lib/backends/opennebula/helpers/compute_parse_helper.rb
+++ b/lib/backends/opennebula/helpers/compute_parse_helper.rb
@@ -84,7 +84,7 @@ module Backends
 
           compute_attrs['occi.compute.cores'] = (backend_compute['TEMPLATE/VCPU'] || 1).to_i
           compute_attrs['occi.compute.memory'] = (backend_compute['TEMPLATE/MEMORY'].to_f / 1024)
-          compute_attrs['occi.compute.speed'] = (backend_compute['TEMPLATE/CPU'] || 1).to_f
+          compute_attrs['occi.compute.speed'] = (backend_compute['TEMPLATE/CPU'] || 1).to_f / compute_attrs['occi.compute.cores']
 
           compute_attrs['occi.compute.architecture'] = 'x64' if backend_compute['TEMPLATE/OS/ARCH'] == 'x86_64'
           compute_attrs['occi.compute.architecture'] = 'x86' if backend_compute['TEMPLATE/OS/ARCH'] == 'i686'

--- a/lib/backends/opennebula/helpers/compute_update_helper.rb
+++ b/lib/backends/opennebula/helpers/compute_update_helper.rb
@@ -1,0 +1,80 @@
+require 'timeout'
+
+module Backends
+  module Opennebula
+    module Helpers
+      module ComputeUpdateHelper
+        COMPUTE_UPDATE_STATES = %w(POWEROFF UNDEPLOYED PENDING STOPPED).freeze
+        COMPUTE_UPDATE_SLEEP = 5
+        COMPUTE_UPDATE_WAIT = 120
+
+        def update_instance_size(instance_id, resource_tpl)
+          virtual_machine = ::OpenNebula::VirtualMachine.new(::OpenNebula::VirtualMachine.build_xml(instance_id), @client)
+          rc = virtual_machine.info
+          check_retval(rc, Backends::Errors::ResourceRetrievalError)
+
+          update_instance_size_stop(virtual_machine)
+          update_instance_size_apply(virtual_machine, resource_tpl)
+          update_instance_size_start(virtual_machine)
+        end
+
+        def update_instance_size_stop(virtual_machine)
+          return if COMPUTE_UPDATE_STATES.include? virtual_machine.state_str
+
+          rc = virtual_machine.poweroff(true)
+          check_retval(rc, Backends::Errors::ResourceActionError)
+          update_instance_wait_for(virtual_machine, 'POWEROFF')
+        end
+
+        def update_instance_size_apply(virtual_machine, resource_tpl)
+          cores = resource_tpl.attributes['occi.compute.cores'].default.to_i
+          memory = (resource_tpl.attributes['occi.compute.memory'].default.to_f * 1024).to_i
+          speed = resource_tpl.attributes['occi.compute.speed'].default.to_f * cores
+
+          resize_template = ''
+          resize_template << "VCPU = #{cores}\n"
+          resize_template << "CPU = #{speed}\n"
+          resize_template << "MEMORY = #{memory}"
+
+          # TODO: resize disk
+          # TODO: update USER_TEMPLATE/MIXINS
+          rc = virtual_machine.resize(resize_template, true)
+          check_retval(rc, Backends::Errors::ResourceActionError)
+        end
+
+        def update_instance_size_start(virtual_machine)
+          rc = virtual_machine.info
+          check_retval(rc, Backends::Errors::ResourceRetrievalError)
+          return if virtual_machine.state_str == 'PENDING'
+
+          rc = virtual_machine.resume
+          check_retval(rc, Backends::Errors::ResourceActionError)
+        end
+
+        def update_instance_resize_tpl(mixins)
+          res_tpls = mixins.to_a.select { |mxn| mxn.related_to? Occi::Infrastructure::ResourceTpl.mixin.type_identifier }
+          fail Backends::Errors::ResourceActionError,
+               'Only resizing is supported! Cannot resize instance to an unknown size!' if res_tpls.empty?
+
+          orig_tpl = res_tpls.first.model.get_by_id(res_tpls.first.type_identifier)
+          fail Backends::Errors::ResourceActionError,
+               'Cannot find the specified resource tpl in the model!' unless orig_tpl
+
+          orig_tpl
+        end
+
+        def update_instance_wait_for(virtual_machine, state)
+          Timeout::timeout(COMPUTE_UPDATE_WAIT) {
+            while virtual_machine.state_str != state
+              rc = virtual_machine.info
+              check_retval(rc, Backends::Errors::ResourceRetrievalError)
+              sleep 5
+            end
+          }
+        rescue Timeout::Error => ex
+          fail Backends::Errors::ResourceActionError, 'Timed out while waiting for state change!'
+        end
+      end
+    end
+  end
+end

--- a/lib/request_parsers/occi/dummy.rb
+++ b/lib/request_parsers/occi/dummy.rb
@@ -1,8 +1,10 @@
 module RequestParsers
   module Occi
     class Dummy
-      def self.parse(media_type, body, headers, path, entity_type = ::Occi::Core::Resource)
-        Rails.logger.debug "[Parser] [#{self}] Parsing media_type='#{media_type}' body='#{body}' headers=#{headers.inspect} path='#{path}' entity_type='#{entity_type.inspect}"
+      def self.parse(media_type, body, headers, path, entity_type, categories)
+        Rails.logger.debug "[Parser] [#{self}] Parsing media_type='#{media_type}' " \
+                           "body='#{body}' headers=#{headers.inspect} path='#{path}' " \
+                           "entity_type='#{entity_type.inspect} categories='#{categories.inspect}'"
         ::Occi::Collection.new
       end
     end

--- a/lib/request_parsers/occi/json.rb
+++ b/lib/request_parsers/occi/json.rb
@@ -1,9 +1,13 @@
 module RequestParsers
   module Occi
     class JSON
-      def self.parse(media_type, body, headers, path, entity_type = ::Occi::Core::Resource)
-        Rails.logger.debug "[Parser] [#{self}] Parsing media_type='#{media_type}' body='#{body}' headers=#{headers.inspect} path='#{path}' entity_type='#{entity_type.inspect}"
-        ::Occi::Parser.parse('application/json', body, path.include?('-/'), entity_type, headers)
+      def self.parse(media_type, body, headers, path, entity_type, categories)
+        Rails.logger.debug "[Parser] [#{self}] Parsing media_type='#{media_type}' " \
+                           "body='#{body}' headers=#{headers.inspect} path='#{path}' " \
+                           "entity_type='#{entity_type.inspect} categories='#{categories.inspect}'"
+        entity_type = entity_type || ::Occi::Core::Resource
+        categories = path.include?('-/') || categories
+        ::Occi::Parser.parse('application/json', body, categories, entity_type, headers)
       end
     end
   end

--- a/lib/request_parsers/occi/text.rb
+++ b/lib/request_parsers/occi/text.rb
@@ -1,9 +1,13 @@
 module RequestParsers
   module Occi
     class Text
-      def self.parse(media_type, body, headers, path, entity_type = ::Occi::Core::Resource)
-        Rails.logger.debug "[Parser] [#{self}] Parsing media_type='#{media_type}' body='#{body}' headers=#{headers.inspect} path='#{path}' entity_type='#{entity_type.inspect}"
-        ::Occi::Parser.parse(media_type, body, path.include?('-/'), entity_type, headers)
+      def self.parse(media_type, body, headers, path, entity_type, categories)
+        Rails.logger.debug "[Parser] [#{self}] Parsing media_type='#{media_type}' " \
+                           "body='#{body}' headers=#{headers.inspect} path='#{path}' " \
+                           "entity_type='#{entity_type.inspect} categories='#{categories.inspect}'"
+        entity_type = entity_type || ::Occi::Core::Resource
+        categories = path.include?('-/') || categories
+        ::Occi::Parser.parse(media_type, body, categories, entity_type, headers)
       end
     end
   end

--- a/lib/request_parsers/occi/xml.rb
+++ b/lib/request_parsers/occi/xml.rb
@@ -1,9 +1,13 @@
 module RequestParsers
   module Occi
     class XML
-      def self.parse(media_type, body, headers, path, entity_type = ::Occi::Core::Resource)
-        Rails.logger.debug "[Parser] [#{self}] Parsing media_type='#{media_type}' body='#{body}' headers=#{headers.inspect} path='#{path}' entity_type='#{entity_type.inspect}"
-        ::Occi::Parser.parse('application/xml', body, path.include?('-/'), entity_type, headers)
+      def self.parse(media_type, body, headers, path, entity_type, categories)
+        Rails.logger.debug "[Parser] [#{self}] Parsing media_type='#{media_type}' " \
+                           "body='#{body}' headers=#{headers.inspect} path='#{path}' " \
+                           "entity_type='#{entity_type.inspect} categories='#{categories.inspect}'"
+        entity_type = entity_type || ::Occi::Core::Resource
+        categories = path.include?('-/') || categories
+        ::Occi::Parser.parse('application/xml', body, categories, entity_type, headers)
       end
     end
   end

--- a/lib/request_parsers/occi_parser.rb
+++ b/lib/request_parsers/occi_parser.rb
@@ -33,14 +33,12 @@ module RequestParsers
       @app.call(env)
     end
 
-    def parse_occi_messages(entity_type = nil)
-      fail ::Errors::UnsupportedMediaTypeError, "Media type '#{@media_type}' is not supported by the RequestParser" unless AVAILABLE_PARSERS.key?(@media_type)
+    def parse_occi_messages(entity_type = nil, categories = false)
+      fail ::Errors::UnsupportedMediaTypeError,
+           "Media type '#{@media_type}' is not supported " \
+           'by the RequestParser' unless AVAILABLE_PARSERS.key?(@media_type)
 
-      collection = if entity_type
-                     AVAILABLE_PARSERS[@media_type].parse(@media_type, @body, @headers, @fullpath, entity_type)
-                   else
-                     AVAILABLE_PARSERS[@media_type].parse(@media_type, @body, @headers, @fullpath)
-                   end
+      collection = AVAILABLE_PARSERS[@media_type].parse(@media_type, @body, @headers, @fullpath, entity_type, categories)
       Rails.logger.debug "[Parser] [#{self.class}] Parsed request into coll=#{collection.inspect}"
 
       collection

--- a/spec/controllers/compute_controller_spec.rb
+++ b/spec/controllers/compute_controller_spec.rb
@@ -160,9 +160,63 @@ X-OCCI-Attribute: occi.compute.hostname="compute1.example.org"|
 
   describe "POST 'partial_update'" do
 
-    it 'return http 501 not implemented' do
+    let(:fake_app) { Proc.new {} }
+    let(:body) {
+      %Q|Category: large;scheme="http://occi.example.org/occi/infrastructure/resource_tpl#";class="mixin"|
+    }
+    let(:body_invalid) { 'not OCCI' }
+
+    let(:setup_success) do
+      env = @request.env
+      env['rack.input'] = StringIO.new(body)
+      env['CONTENT_TYPE'] = 'text/plain'
+      @request.env['rocci_server.request.parser'].call(env)
+    end
+
+    let(:setup_empty_fail) do
+      env = @request.env
+      env['rack.input'] = StringIO.new('')
+      env['CONTENT_TYPE'] = 'text/plain'
+      @request.env['rocci_server.request.parser'].call(env)
+    end
+
+    let(:setup_invl_fail) do
+      env = @request.env
+      env['rack.input'] = StringIO.new(body_invalid)
+      env['CONTENT_TYPE'] = 'text/plain'
+      @request.env['rocci_server.request.parser'].call(env)
+    end
+
+    before(:each){
+      @request.env['rocci_server.request.parser'] ||= ::RequestParsers::OcciParser.new(fake_app)
+    }
+
+    it 'returns http bad request without body' do
+      setup_empty_fail
+
       post 'partial_update', format: :text, id: '87f3bfc3-42d4-4474-b45c-757e55e093e9'
-      expect(response.status).to eq 501
+      expect(response).to be_bad_request
+    end
+
+    it 'returns http bad request with invalid body' do
+      setup_invl_fail
+
+      post 'partial_update', format: :text, id: '87f3bfc3-42d4-4474-b45c-757e55e093e9'
+      expect(response).to be_bad_request
+    end
+
+    it 'returns http created on success' do
+      setup_success
+
+      post 'partial_update', format: :text, id: '87f3bfc3-42d4-4474-b45c-757e55e093e9'
+      expect(response).to be_success
+    end
+
+    it 'returns http not found on non-existing resource' do
+      setup_success
+
+      post 'partial_update', format: :text, id: 'not_there'
+      expect(response).to be_not_found
     end
 
   end
@@ -172,10 +226,10 @@ X-OCCI-Attribute: occi.compute.hostname="compute1.example.org"|
     let(:fake_app) { Proc.new {} }
     let(:body) {
       %Q|Category: compute;scheme="http://schemas.ogf.org/occi/infrastructure#";class="kind"
-X-OCCI-Attribute: occi.core.id="87f3bfc3-42d4-4474-b45c-757e55e093e9"
-X-OCCI-Attribute: occi.core.title="Compute1"
-X-OCCI-Attribute: occi.core.summary="Scientific Linux 6.2 Boron"
-X-OCCI-Attribute: occi.compute.hostname="compute1.example.org"|
+  X-OCCI-Attribute: occi.core.id="87f3bfc3-42d4-4474-b45c-757e55e093e9"
+  X-OCCI-Attribute: occi.core.title="Compute1"
+  X-OCCI-Attribute: occi.core.summary="Scientific Linux 6.2 Boron"
+  X-OCCI-Attribute: occi.compute.hostname="compute1.example.org"|
     }
     let(:body_invalid) { 'not OCCI' }
 

--- a/spec/controllers/networkinterface_controller_spec.rb
+++ b/spec/controllers/networkinterface_controller_spec.rb
@@ -13,4 +13,38 @@ describe NetworkinterfaceController do
 
   end
 
+  describe "GET 'index'" do
+
+    it 'returns list' do
+      get 'index', format: :uri_list
+      expect(response).to be_success
+    end
+
+    it 'returns an array by default' do
+      get 'index', format: '*/*'
+      expect(assigns(:nis)).to be_kind_of(Array)
+    end
+
+    it 'returns a collection for text/html' do
+      get 'index', format: :html
+      expect(assigns(:nis)).to be_kind_of(Occi::Collection)
+    end
+
+    it 'returns an array for text/uri-list' do
+      get 'index', format: :uri_list
+      expect(assigns(:nis)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/plain' do
+      get 'index', format: :text
+      expect(assigns(:nis)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/occi' do
+      get 'index', format: :occi_header
+      expect(assigns(:nis)).to be_kind_of(Array)
+    end
+
+  end
+
 end

--- a/spec/controllers/storagelink_controller_spec.rb
+++ b/spec/controllers/storagelink_controller_spec.rb
@@ -13,4 +13,38 @@ describe StoragelinkController do
 
   end
 
+  describe "GET 'index'" do
+
+    it 'returns list' do
+      get 'index', format: :uri_list
+      expect(response).to be_success
+    end
+
+    it 'returns an array by default' do
+      get 'index', format: '*/*'
+      expect(assigns(:sls)).to be_kind_of(Array)
+    end
+
+    it 'returns a collection for text/html' do
+      get 'index', format: :html
+      expect(assigns(:sls)).to be_kind_of(Occi::Collection)
+    end
+
+    it 'returns an array for text/uri-list' do
+      get 'index', format: :uri_list
+      expect(assigns(:sls)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/plain' do
+      get 'index', format: :text
+      expect(assigns(:sls)).to be_kind_of(Array)
+    end
+
+    it 'returns an array for text/occi' do
+      get 'index', format: :occi_header
+      expect(assigns(:sls)).to be_kind_of(Array)
+    end
+
+  end
+
 end


### PR DESCRIPTION
There are two ways to resize an existing `compute` instance:

1. Calling `POST` with a selected `resource_tpl` mixin on `/compute/:id`
2. Calling `PUT` with a full `compute` rendering on `/compute/:id`

In response, the server will return a full rendering of the updated `compute` instance.
## Example
```
POST /compute/15 HTTP/1.1
(other headers omitted)
Content-Type: text/plain; charset=utf-8

Category: atlas;scheme="http://fedcloud.egi.eu/occi/infrastructure/resource_tpl#";class="mixin"
```