### PR TITLE
[ONE] Added support for cloning (full snap.)

### DIFF
--- a/app/controllers/compute_controller.rb
+++ b/app/controllers/compute_controller.rb
@@ -50,8 +50,9 @@ class ComputeController < ApplicationController
              else
                backend_instance.compute_trigger_action_on_all(ai)
              end
-
-    result ? respond_with(Occi::Collection.new) : respond_with(Occi::Collection.new, status: 304)
+    coll = Occi::Collection.new
+    coll.mixins = result if result.kind_of? Occi::Core::Mixins
+    result ? respond_with(coll) : respond_with(coll, status: 304)
   end
 
   # POST /compute/:id

--- a/lib/backends/opennebula/helpers/compute_parse_helper.rb
+++ b/lib/backends/opennebula/helpers/compute_parse_helper.rb
@@ -127,7 +127,10 @@ module Backends
             result.actions = []
           when 'STOPPED', 'SUSPENDED', 'POWEROFF', 'UNDEPLOYED'
             result.state = 'suspended'
-            result.actions = %w|http://schemas.ogf.org/occi/infrastructure/compute/action#start|
+            result.actions = %w(
+              http://schemas.ogf.org/occi/infrastructure/compute/action#start
+              http://schemas.ogf.org/occi/infrastructure/compute/action#save
+            )
           when 'PENDING', 'HOLD', 'CLONING'
             result.state = 'waiting'
             result.actions = []
@@ -147,6 +150,7 @@ module Backends
               http://schemas.ogf.org/occi/infrastructure/compute/action#stop
               http://schemas.ogf.org/occi/infrastructure/compute/action#restart
               http://schemas.ogf.org/occi/infrastructure/compute/action#suspend
+              http://schemas.ogf.org/occi/infrastructure/compute/action#save
             )
           when 'PROLOG', 'BOOT', 'MIGRATE', 'EPILOG'
             result.state = 'waiting'


### PR DESCRIPTION
The newly defined action `http://schemas.ogf.org/occi/infrastructure/compute/action#save` on `compute` can be triggered as any other action. On success, the call will return full rendering of the newly created `os_tpl` mixin.