### PR TITLE
[ONE] Saving user identity to metadata for accouting

### DIFF
--- a/etc/backends/opennebula/templates/network.erb
+++ b/etc/backends/opennebula/templates/network.erb
@@ -14,7 +14,10 @@ VLAN    = "no"
 BRIDGE  = "onebr0"
 <% end %>
 
-
+USER_IDENTITY = "<%= @identity[:delegated_user].identity %>"
+<% if @identity[:dn_auth] %>
+USER_X509_DN  = "<%= @identity[:delegated_user].identity %>"
+<% end %>
 
 <% if @network.address %>
   <% network_range = IPAddr.new(@network.address).to_range %>

--- a/etc/backends/opennebula/templates/storage.erb
+++ b/etc/backends/opennebula/templates/storage.erb
@@ -4,8 +4,13 @@ NAME = "<%= @storage.title %>"
 DESCRIPTION = "<%= @storage.summary || "STORAGE created using rOCCI-server on #{::DateTime.now.readable_inspect}." %>"
 
 TYPE = "DATABLOCK"
-SIZE = "<%= @storage.size ? (@storage.size.to_f * 1024).to_i : 10240 %>"
+SIZE = "<%= @storage.size ? (@storage.size.to_f * 1024).to_i : 1024 %>"
 
 PERSISTENT = "YES"
 DRIVER = "raw"
 FSTYPE = "raw"
+
+USER_IDENTITY = "<%= @identity[:delegated_user].identity %>"
+<% if @identity[:dn_auth] %>
+USER_X509_DN  = "<%= @identity[:delegated_user].identity %>"
+<% end %>

--- a/lib/backends/opennebula/base.rb
+++ b/lib/backends/opennebula/base.rb
@@ -4,6 +4,7 @@ module Backends
       API_VERSION = '2.0.0'.freeze
       TPL_TERM_PREFIX = 'uuid'.freeze
       AVAIL_ZONE_MIXIN = 'http://fedcloud.egi.eu/occi/infrastructure#availability_zone'.freeze
+      DN_BASED_AUTHS = %w(x509 voms).freeze
 
       # load helpers for JSON -> Collection conversion
       include Backends::Helpers::JsonCollectionHelper

--- a/lib/backends/opennebula/helpers/compute_create_helper.rb
+++ b/lib/backends/opennebula/helpers/compute_create_helper.rb
@@ -5,7 +5,6 @@ module Backends
         COMPUTE_SSH_REGEXP = /^(command=.+\s)?((?:ssh\-|ecds)[\w-]+\s.+)$/
         COMPUTE_BASE64_REGEXP = /^[A-Za-z0-9+\/]+={0,2}$/
         COMPUTE_USER_DATA_SIZE_LIMIT = 16384
-        COMPUTE_DN_BASED_AUTHS = %w(x509 voms).freeze
 
         def create_with_os_tpl(compute)
           @logger.debug "[Backends] [Opennebula] Deploying #{compute.inspect}"
@@ -204,7 +203,7 @@ module Backends
 
           # add user identity info
           template.add_element('TEMPLATE',  'USER_IDENTITY' => @delegated_user.identity)
-          if COMPUTE_DN_BASED_AUTHS.include?(@delegated_user.auth_.type)
+          if DN_BASED_AUTHS.include?(@delegated_user.auth_.type)
             template.add_element('TEMPLATE',  'USER_X509_DN' => @delegated_user.identity)
           end
         end

--- a/lib/backends/opennebula/network.rb
+++ b/lib/backends/opennebula/network.rb
@@ -98,8 +98,12 @@ module Backends
         network.mixins << 'http://schemas.ogf.org/occi/infrastructure/network#ipnetwork'
         network.attributes = attr_backup
 
+        identity = {}
+        identity[:delegated_user] = @delegated_user
+        identity[:dn_auth] = DN_BASED_AUTHS.include?(@delegated_user.auth_.type)
+
         template_location = File.join(@options.templates_dir, 'network.erb')
-        template = Erubis::Eruby.new(File.read(template_location)).evaluate(network: network)
+        template = Erubis::Eruby.new(File.read(template_location)).evaluate(network: network, identity: identity)
 
         @logger.debug "[Backends] [Opennebula] Template #{template.inspect}"
 

--- a/lib/backends/opennebula/storage.rb
+++ b/lib/backends/opennebula/storage.rb
@@ -93,8 +93,12 @@ module Backends
         @logger.debug "[Backends] [Opennebula] Creating storage #{storage.inspect} "\
                       "in DS[#{@options.storage_datastore_id}]"
 
+        identity = {}
+        identity[:delegated_user] = @delegated_user
+        identity[:dn_auth] = DN_BASED_AUTHS.include?(@delegated_user.auth_.type)
+
         template_location = File.join(@options.templates_dir, 'storage.erb')
-        template = Erubis::Eruby.new(File.read(template_location)).evaluate(storage: storage)
+        template = Erubis::Eruby.new(File.read(template_location)).evaluate(storage: storage, identity: identity)
 
         @logger.debug "[Backends] [Opennebula] Template #{template.inspect}"
 


### PR DESCRIPTION
For OpenNebula, user's identity is now stored in all user-defined resources, for accounting purposes.