### PR TITLE
Fixed typo in error class

### DIFF
--- a/app/jobs/opennebula/compute_resize_job.rb
+++ b/app/jobs/opennebula/compute_resize_job.rb
@@ -9,7 +9,7 @@ module Opennebula
       logger.error "Delayed job failed: #{ex}"
     end
 
-    rescue_from(Errors::Backend::EntityTimeoutErrror) do |_ex|
+    rescue_from(Errors::Backend::EntityTimeoutError) do |_ex|
       logger.error "Timed out while waiting for job completion [#{DEFAULT_TIMEOUT}s]"
     end
 

--- a/app/lib/backends/opennebula/helpers/waiter.rb
+++ b/app/lib/backends/opennebula/helpers/waiter.rb
@@ -18,7 +18,7 @@ module Backends
         # @param timeout [Fixnum] wait for given number of seconds
         # @param type [Symbol] type of the state
         def wait_until(virtual_machine, state, timeout = 60, type = :lcm_state_str)
-          Timeout.timeout(timeout, Errors::Backend::EntityTimeoutErrror) do
+          Timeout.timeout(timeout, Errors::Backend::EntityTimeoutError) do
             loop do
               sleep WAITER_STEP
               client(Errors::Backend::EntityRetrievalError) { virtual_machine.info }


### PR DESCRIPTION
`EntityTimeoutErrror` -> `EntityTimeoutError`